### PR TITLE
Add Luci Encoder data to client and interface

### DIFF
--- a/docs/grpc_package.md
+++ b/docs/grpc_package.md
@@ -20,12 +20,13 @@ You are likely to always use this node if using the LUCI SDK.
 | no | luci/chair_velocity | publisher | geometry_msgs::msg::Twist | Linear and angular velocity of the chair according to onboard AHRS **Note: “linear velocity” will be speed not velocity** |
 | coming soon | luci/all_sensor_points | publisher | sensor_msgs::msg::PointCloud2 | Full pointcloud (All LUCI sensors) |
 | partially | luci/odom | publisher | nav_msgs::msg::Odometry | AHRS odom reading |
-|yes|luci/imu|publisher|luci_messages::msg::LuciImu|Raw IMU data from the LUCI system|
+| yes | luci/imu|publisher|luci_messages::msg::LuciImu|Raw IMU data from the LUCI system|
 | yes | luci/ultrasonic_points | publisher | sensor_msgs::msg::PointCloud2 | Ultrasonic pointcloud |
 | yes | luci/radar_points | publisher | sensor_msgs::msg::PointCloud2 | Radar pointcloud |
 | yes | luci/camera_points | publisher | sensor_msgs::msg::PointCloud2 | Camera poincloud |
 | yes | luci/scaling | publisher | luci_messages::msg::LuciScaling | Scaling percentage of each zone LUCI sees (100% => full ability to drive) |
 | yes | luci/joystick_scaling | publisher | luci_messages::msg::LuciJoystick | Scaled Joystick values of the chair (FB:xxx, LR: xxx) |
+| yes | luci/encoder | publisher | luci_messages::msg::LuciEncoders | Raw Encoder data from the LUCI system |
 | no | luci/ir_left_camera | publisher | sensor_msgs::msg::Image | Left camera’s IR frame |
 | no | luci/ir_right_camera | publisher | sensor_msgs::msg::Image | Right camera’s IR frame |
 | no | luci/ir_back_camera | publisher | sensor_msgs::msg::Image | Back camera’s IR frame |

--- a/luci_grpc_interface/client/include/client/client.h
+++ b/luci_grpc_interface/client/include/client/client.h
@@ -55,6 +55,8 @@ class ClientGuide
      * @param zoneScalingDataBuff
      * @param joystickScalingDataBuff
      * @param ahrsInfoBuff
+     * @param imuDataBuff
+     * @param encoderDataBuff
      */
     explicit ClientGuide(
         std::shared_ptr<grpc::Channel> channel,
@@ -65,7 +67,8 @@ class ClientGuide
         std::shared_ptr<DataBuffer<LuciZoneScaling>> zoneScalingDataBuff,
         std::shared_ptr<DataBuffer<LuciJoystickScaling>> joystickScalingDataBuff,
         std::shared_ptr<DataBuffer<AhrsInfo>> ahrsInfoBuff,
-        std::shared_ptr<DataBuffer<ImuData>> imuDataBuff);
+        std::shared_ptr<DataBuffer<ImuData>> imuDataBuff,
+        std::shared_ptr<DataBuffer<EncoderData>> encoderDataBuff);
 
     /**
      * @brief Destroy the Client Guide object
@@ -89,6 +92,7 @@ class ClientGuide
     std::shared_ptr<DataBuffer<SystemJoystick>> joystickDataBuff;
     std::shared_ptr<DataBuffer<AhrsInfo>> ahrsDataBuff;
     std::shared_ptr<DataBuffer<ImuData>> imuDataBuff;
+    std::shared_ptr<DataBuffer<EncoderData>> encoderDataBuff;
 
     // Single calls over gRPC
 
@@ -171,6 +175,12 @@ class ClientGuide
      *
      */
     void readImuData() const;
+
+    /**
+     * @brief Read the chairs encoder data
+     *
+     */
+    void readEncoderData() const;
 
   private:
     /// Threads for each endpoint

--- a/luci_grpc_interface/client/include/client/common_types.h
+++ b/luci_grpc_interface/client/include/client/common_types.h
@@ -97,7 +97,7 @@ struct AhrsInfo
 
 /**
  * @brief LUCI IMU Data
- * 
+ *
  */
 struct ImuData
 {
@@ -152,6 +152,28 @@ struct ImuData
           magnetometer_x(magnetometer_x), magnetometer_y(magnetometer_y),
           magnetometer_z(magnetometer_z), gravity_x(gravity_x), gravity_y(gravity_y),
           gravity_z(gravity_z), source(source)
+    {
+    }
+};
+
+/**
+ * @brief LUCI Encoder data
+ *
+ */
+struct EncoderData
+{
+    float left_angle;
+    float right_angle;
+    float fl_caster_degrees;
+    float bl_caster_degrees;
+    float fr_caster_degrees;
+    float br_caster_degrees;
+
+    inline EncoderData(float left_angle, float right_angle, float fl_caster_degrees,
+                    float bl_caster_degrees, float fr_caster_degrees, float br_caster_degrees)
+        : left_angle(left_angle), right_angle(right_angle), fl_caster_degrees(fl_caster_degrees),
+          bl_caster_degrees(bl_caster_degrees), fr_caster_degrees(fr_caster_degrees),
+          br_caster_degrees(br_caster_degrees)
     {
     }
 };

--- a/luci_grpc_interface/interface/src/interface.cpp
+++ b/luci_grpc_interface/interface/src/interface.cpp
@@ -205,6 +205,33 @@ void Interface::processImuData()
     }
 }
 
+void Interface::processEncoderData()
+{
+    // Wait on new IMU data from gRPC and then send out conveted ROS2 message
+    while (true)
+    {
+        auto encoderData = this->encoderDataBuff->waitNext();
+
+        luci_messages::msg::LuciEncoders rosEncoderMsg;
+        // Header
+        std_msgs::msg::Header encoderHeader;
+        encoderHeader.frame_id = "base_link";
+        encoderHeader.stamp = this->get_clock()->now();
+
+        rosEncoderMsg.header = encoderHeader;
+
+        rosEncoderMsg.left_angle = encoderData.left_angle;
+        rosEncoderMsg.right_angle = encoderData.right_angle;
+
+        rosEncoderMsg.fl_caster_degrees = encoderData.fl_caster_degrees;
+        rosEncoderMsg.bl_caster_degrees = encoderData.bl_caster_degrees;
+        rosEncoderMsg.fr_caster_degrees = encoderData.fr_caster_degrees;
+        rosEncoderMsg.br_caster_degrees = encoderData.br_caster_degrees;
+
+        this->encoderPublisher->publish(rosEncoderMsg);
+    }
+}
+
 void Interface::sendJsCallback(const luci_messages::msg::LuciJoystick::SharedPtr msg)
 {
     // Send the remote JS values over gRPC

--- a/luci_grpc_interface/interface/src/main.cpp
+++ b/luci_grpc_interface/interface/src/main.cpp
@@ -64,6 +64,8 @@ int main(int argc, char* argv[])
 
     auto imuDataBuff = std::make_shared<Luci::ROS2::DataBuffer<ImuData>>();
 
+    auto encoderDataBuff = std::make_shared<Luci::ROS2::DataBuffer<EncoderData>>();
+
     auto cameraDataBuff =
         std::make_shared<Luci::ROS2::DataBuffer<pcl::PointCloud<pcl::PointXYZ>>>();
 
@@ -84,12 +86,14 @@ int main(int argc, char* argv[])
     // gRPC connection to LUCI
     auto luciInterface = std::make_shared<Luci::ROS2::ClientGuide>(
         grpcChannel, joystickDataBuff, cameraDataBuff, radarDataBuff, ultrasonicDataBuff,
-        zoneScalingDataBuff, joystickScalingDataBuff, ahrsInfoDataBuff, imuDataBuff);
+        zoneScalingDataBuff, joystickScalingDataBuff, ahrsInfoDataBuff, imuDataBuff,
+        encoderDataBuff);
 
     // ROS connection
     auto interface_node = std::make_shared<Interface>(
         luciInterface, cameraDataBuff, radarDataBuff, ultrasonicDataBuff, joystickDataBuff,
-        zoneScalingDataBuff, joystickScalingDataBuff, ahrsInfoDataBuff, imuDataBuff);
+        zoneScalingDataBuff, joystickScalingDataBuff, ahrsInfoDataBuff, imuDataBuff,
+        encoderDataBuff);
 
     executor.add_node(interface_node);
     spdlog::debug("Running grpc interface");


### PR DESCRIPTION
Add Luci Encoder topic.

Tested using Dave (with encoders installed) using the FoxGlove bridge and the related PR (linked below) and was able to see encoder data. 

Related PR: https://github.com/lucimobility/luci-ros2-msgs/pull/9