### PR TITLE
LUCI-529 , LUCI-1125 - Get SDK compatible with LUCI-3.X.X

### DIFF
--- a/luci_grpc_interface/clang-format-all.sh
+++ b/luci_grpc_interface/clang-format-all.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+find . -regex '.*\.\(cpp\|h\)' \
+    -not -path "./tclap/*" \
+    -not -path "*/third_party/*" \
+    -not -path "*/generated_code/*" -print0 | \
+    xargs -0 -n1 -P16 clang-format-14 -style=file -i 

--- a/luci_grpc_interface/client/include/client/client.h
+++ b/luci_grpc_interface/client/include/client/client.h
@@ -129,35 +129,17 @@ class ClientGuide
     // Single calls over gRPC
 
     /**
-     * @brief Interface to turn on engaged mode at the msp level
+     * @brief Set the input source for the chair
      *
-     * @return bool success code (true-success, false-failure)
+     * @param source The input source to set
+     * @return int success code (0-success, 1-failure)
      */
-    bool activateEngagedMode() const;
+    int setInputSource(InputSource source) const;
 
     /**
-     * @brief Interface to turn on user mode at the msp level
+     * @brief Remove the input source for the chair
      *
-     * @return bool success code (true-success, false-failure)
-     */
-    bool activateUserMode() const;
-
-    /**
-     * @brief Interface to turn on auto mode at the msp level
-     *
-     * @return bool success code (true-success, false-failure)
-     */
-    bool activateAutoMode() const;
-
-    /**
-     * @brief Set the input source for the chair to remote
-     *
-     */
-    void setInputSource(InputSource source) const;
-
-    /**
-     * @brief Remove the input source for the chair remote
-     *
+     * @param source The input source to remove
      */
     void removeInputSource(InputSource source) const;
 

--- a/luci_grpc_interface/client/include/client/client.h
+++ b/luci_grpc_interface/client/include/client/client.h
@@ -151,13 +151,13 @@ class ClientGuide
 
     /**
      * @brief Set the input source for the chair to remote
-     * 
+     *
      */
     void setInputSource(InputSource source) const;
 
     /**
      * @brief Remove the input source for the chair remote
-     * 
+     *
      */
     void removeInputSource(InputSource source) const;
 

--- a/luci_grpc_interface/client/include/client/client.h
+++ b/luci_grpc_interface/client/include/client/client.h
@@ -150,13 +150,26 @@ class ClientGuide
     bool activateAutoMode() const;
 
     /**
+     * @brief Set the input source for the chair to remote
+     * 
+     */
+    void setInputSource(InputSource source) const;
+
+    /**
+     * @brief Remove the input source for the chair remote
+     * 
+     */
+    void removeInputSource(InputSource source) const;
+
+    /**
      * @brief Send JS values to luci sensors
      *
      * @param forwardBack
      * @param leftRight
+     * @param source
      * @return int success code (0-success, 1-failure)
      */
-    int sendJS(int forwardBack, int leftRight);
+    int sendJS(int forwardBack, int leftRight, InputSource source);
 
     /**
      * @brief Updates the IR frame rate while a stream is already active. This is used by clients

--- a/luci_grpc_interface/client/include/client/client.h
+++ b/luci_grpc_interface/client/include/client/client.h
@@ -42,6 +42,7 @@
 #include <thread>
 #include <vector>
 
+using sensors::ActiveScaling;
 using sensors::AhrsData;
 using sensors::CameraMetaData;
 using sensors::CameraPoints;
@@ -88,7 +89,7 @@ class ClientGuide
         std::shared_ptr<DataBuffer<pcl::PointCloud<pcl::PointXYZ>>> radarDataBuff,
         std::shared_ptr<DataBuffer<pcl::PointCloud<pcl::PointXYZ>>> ultrasonicDataBuff,
         std::shared_ptr<DataBuffer<LuciZoneScaling>> zoneScalingDataBuff,
-        std::shared_ptr<DataBuffer<SystemJoystick>> joystickScalingDataBuff,
+        std::shared_ptr<DataBuffer<LuciJoystickScaling>> joystickScalingDataBuff,
         std::shared_ptr<DataBuffer<AhrsInfo>> ahrsInfoBuff,
         std::shared_ptr<DataBuffer<ImuData>> imuDataBuff,
         std::shared_ptr<DataBuffer<EncoderData>> encoderDataBuff,
@@ -114,7 +115,7 @@ class ClientGuide
     std::shared_ptr<DataBuffer<pcl::PointCloud<pcl::PointXYZ>>> radarDataBuff;
     std::shared_ptr<DataBuffer<pcl::PointCloud<pcl::PointXYZ>>> ultrasonicDataBuff;
     std::shared_ptr<DataBuffer<LuciZoneScaling>> zoneScalingDataBuff;
-    std::shared_ptr<DataBuffer<SystemJoystick>> joystickScalingDataBuff;
+    std::shared_ptr<DataBuffer<LuciJoystickScaling>> joystickScalingDataBuff;
     std::shared_ptr<DataBuffer<SystemJoystick>> joystickDataBuff;
     std::shared_ptr<DataBuffer<AhrsInfo>> ahrsDataBuff;
     std::shared_ptr<DataBuffer<ImuData>> imuDataBuff;

--- a/luci_grpc_interface/client/include/client/common_types.h
+++ b/luci_grpc_interface/client/include/client/common_types.h
@@ -24,24 +24,24 @@
 
 enum class JoystickZone
 {
-  Front = 0,
-  FrontLeft =1,
-  FrontRight =2,
-  Left =3,
-  Right=4,
-  BackLeft=5,
-  BackRight=6,
-  Back=7,
-  Origin=8,
+    Front = 0,
+    FrontLeft = 1,
+    FrontRight = 2,
+    Left = 3,
+    Right = 4,
+    BackLeft = 5,
+    BackRight = 6,
+    Back = 7,
+    Origin = 8,
 };
 
 enum class InputSource
 {
-        RampAssist =0 ,
-        Remote =1 ,
-        WDI =2,
-        ChairVirtual =3 ,
-        ChairPhysical =4 ,
+    RampAssist = 0,
+    Remote = 1,
+    WDI = 2,
+    ChairVirtual = 3,
+    ChairPhysical = 4,
 };
 
 /**
@@ -55,8 +55,10 @@ struct SystemJoystick
     JoystickZone joystick_zone;
     InputSource input_source;
 
-    inline SystemJoystick(int forward_back, int left_right, JoystickZone joystick_zone, InputSource input_source)
-        : forward_back(forward_back), left_right(left_right), joystick_zone(joystick_zone), input_source(input_source)
+    inline SystemJoystick(int forward_back, int left_right, JoystickZone joystick_zone,
+                          InputSource input_source)
+        : forward_back(forward_back), left_right(left_right), joystick_zone(joystick_zone),
+          input_source(input_source)
     {
     }
 };
@@ -196,7 +198,8 @@ struct EncoderData
     int edge_timestamp;
 
     inline EncoderData(float left_angle, float right_angle, float fl_caster_degrees,
-                       float bl_caster_degrees, float fr_caster_degrees, float br_caster_degrees, int edge_timestamp)
+                       float bl_caster_degrees, float fr_caster_degrees, float br_caster_degrees,
+                       int edge_timestamp)
         : left_angle(left_angle), right_angle(right_angle), fl_caster_degrees(fl_caster_degrees),
           bl_caster_degrees(bl_caster_degrees), fr_caster_degrees(fr_caster_degrees),
           br_caster_degrees(br_caster_degrees), edge_timestamp(edge_timestamp)

--- a/luci_grpc_interface/client/include/client/common_types.h
+++ b/luci_grpc_interface/client/include/client/common_types.h
@@ -38,10 +38,11 @@ enum class JoystickZone
 enum class InputSource
 {
     RampAssist = 0,
-    Remote = 1,
+    AutonomousRemote = 1,
     WDI = 2,
     ChairVirtual = 3,
     ChairPhysical = 4,
+    SharedRemote = 5,
 };
 
 /**
@@ -64,7 +65,7 @@ struct SystemJoystick
 };
 
 /**
- * @brief LUCI scaling zones
+ * @brief LUCI zone scaling
  *
  */
 struct LuciZoneScaling
@@ -96,6 +97,29 @@ struct LuciZoneScaling
           front_left_rl(front_left_rl), right_fb(right_fb), right_rl(right_rl), left_fb(left_fb),
           left_rl(left_rl), back_right_fb(back_right_fb), back_right_rl(back_right_rl),
           back_left_fb(back_left_fb), back_left_rl(back_left_rl), back_fb(back_fb), back_rl(back_rl)
+    {
+    }
+};
+
+/**
+ * @brief LUCI joystick scaling
+ *
+ */
+struct LuciJoystickScaling
+{
+    int forward_back;
+    int left_right;
+    JoystickZone joystick_zone;
+    InputSource input_source;
+    float forward_back_scaling;
+    float left_right_scaling;
+
+    inline LuciJoystickScaling(int forward_back, int left_right, JoystickZone joystick_zone,
+                               InputSource input_source, float forward_back_scaling,
+                               float left_right_scaling)
+        : forward_back(forward_back), left_right(left_right), joystick_zone(joystick_zone),
+          input_source(input_source), forward_back_scaling(forward_back_scaling),
+          left_right_scaling(left_right_scaling)
     {
     }
 };

--- a/luci_grpc_interface/client/include/client/common_types.h
+++ b/luci_grpc_interface/client/include/client/common_types.h
@@ -22,6 +22,28 @@
 #include <string>
 #include <vector>
 
+enum class JoystickZone
+{
+  Front = 0,
+  FrontLeft =1,
+  FrontRight =2,
+  Left =3,
+  Right=4,
+  BackLeft=5,
+  BackRight=6,
+  Back=7,
+  Origin=8,
+};
+
+enum class InputSource
+{
+        RampAssist =0 ,
+        Remote =1 ,
+        WDI =2,
+        ChairVirtual =3 ,
+        ChairPhysical =4 ,
+};
+
 /**
  * @brief LUCI joystick
  *
@@ -30,10 +52,11 @@ struct SystemJoystick
 {
     int forward_back;
     int left_right;
-    std::string joystick_zone;
+    JoystickZone joystick_zone;
+    InputSource input_source;
 
-    inline SystemJoystick(int forward_back, int left_right, std::string joystick_zone)
-        : forward_back(forward_back), left_right(left_right), joystick_zone(joystick_zone)
+    inline SystemJoystick(int forward_back, int left_right, JoystickZone joystick_zone, InputSource input_source)
+        : forward_back(forward_back), left_right(left_right), joystick_zone(joystick_zone), input_source(input_source)
     {
     }
 };

--- a/luci_grpc_interface/client/src/client.cpp
+++ b/luci_grpc_interface/client/src/client.cpp
@@ -92,7 +92,7 @@ sensors::JoystickZone convertJoystickZoneToProto(const JoystickZone zone)
         return sensors::JoystickZone::Back;
     case JoystickZone::Origin:
         return sensors::JoystickZone::Origin;
-    // default:
+        // default:
         // spdlog::error("Unexpected luci joystick zone {}, defaulting to origin", zone);
     }
     return sensors::JoystickZone::Origin;
@@ -120,7 +120,7 @@ JoystickZone convertProtoZone(const sensors::JoystickZone zone)
         return JoystickZone::Back;
     case sensors::JoystickZone::Origin:
         return JoystickZone::Origin;
-    // default:
+        // default:
         // spdlog::error("Unexpected sensors joystick zone {}, defaulting to origin", zone);
     }
     return JoystickZone::Origin;
@@ -140,9 +140,10 @@ sensors::InputSource convertInputSourceToProto(const InputSource inputSource)
         return sensors::InputSource::ChairVirtual;
     case InputSource::ChairPhysical:
         return sensors::InputSource::ChairPhysical;
-    // default:
-    //     spdlog::error("Unexpected luci input source {}, defaulting to chair virtual input source",
-    //                   inputSource);
+        // default:
+        //     spdlog::error("Unexpected luci input source {}, defaulting to chair virtual input
+        //     source",
+        //                   inputSource);
     }
     return sensors::InputSource::ChairVirtual;
 }
@@ -161,10 +162,10 @@ InputSource convertProtoInputSource(const sensors::InputSource inputSource)
         return InputSource::ChairVirtual;
     case sensors::InputSource::ChairPhysical:
         return InputSource::ChairPhysical;
-    // default:
-    //     spdlog::error(
-    //         "Unexpected sensors input source {}, defaulting to chair virtual input source",
-    //         inputSource);
+        // default:
+        //     spdlog::error(
+        //         "Unexpected sensors input source {}, defaulting to chair virtual input source",
+        //         inputSource);
     }
     return InputSource::ChairVirtual;
 }
@@ -237,7 +238,7 @@ void ClientGuide::setInputSource(InputSource source) const
     ClientContext context;
     sensors::InputSourceRequest request;
     Response response;
-    
+
     request.set_source(convertInputSourceToProto(source));
 
     if (Status status = stub_->AddInputSource(&context, request, &response); status.ok())
@@ -274,7 +275,7 @@ int ClientGuide::sendJS(int forwardBack, int leftRight, InputSource source)
     ClientContext context;
     Response response;
     RemoteJsValues request;
-    
+
     request.set_left_right(leftRight);
     request.set_forward_back(forwardBack);
     request.set_source(convertInputSourceToProto(source));
@@ -284,7 +285,8 @@ int ClientGuide::sendJS(int forwardBack, int leftRight, InputSource source)
     if (Status status = stub_->JsOverride(&context, request, &response); status.ok())
     {
         spdlog::info("Sending remote call... values ({} {} {}) status: {}",
-                     std::to_string(forwardBack), std::to_string(leftRight), std::to_string(static_cast<int>(source)), response.reply());
+                     std::to_string(forwardBack), std::to_string(leftRight),
+                     std::to_string(static_cast<int>(source)), response.reply());
     }
     else
     {
@@ -311,7 +313,8 @@ void ClientGuide::readJoystickPosition() const
     while (reader->Read(&response))
     {
         SystemJoystick joystickValues(response.forward_back(), response.left_right(),
-        convertProtoZone(response.joystick_zone()), convertProtoInputSource(response.source()));
+                                      convertProtoZone(response.joystick_zone()),
+                                      convertProtoInputSource(response.source()));
 
         this->joystickDataBuff->push(joystickValues);
     }
@@ -433,7 +436,8 @@ void ClientGuide::readJoystickScalingData() const
     while (reader->Read(&response))
     {
         SystemJoystick scalingValues(response.forward_back(), response.left_right(),
-        convertProtoZone(response.joystick_zone()), convertProtoInputSource(response.source()));
+                                     convertProtoZone(response.joystick_zone()),
+                                     convertProtoInputSource(response.source()));
 
         this->joystickScalingDataBuff->push(scalingValues);
     }

--- a/luci_grpc_interface/client/src/client.cpp
+++ b/luci_grpc_interface/client/src/client.cpp
@@ -29,8 +29,6 @@ using grpc::Status;
 
 using Luci::ROS2::ClientGuide;
 
-using sensors::DriveMode;
-using sensors::ModeCtrl;
 using sensors::RemoteJsValues;
 using sensors::Response;
 
@@ -92,8 +90,8 @@ sensors::JoystickZone convertJoystickZoneToProto(const JoystickZone zone)
         return sensors::JoystickZone::Back;
     case JoystickZone::Origin:
         return sensors::JoystickZone::Origin;
-        // default:
-        // spdlog::error("Unexpected luci joystick zone {}, defaulting to origin", zone);
+    default:
+        spdlog::error("Unexpected luci joystick zone {}, defaulting to origin", static_cast<int>(zone));
     }
     return sensors::JoystickZone::Origin;
 }
@@ -120,8 +118,8 @@ JoystickZone convertProtoZone(const sensors::JoystickZone zone)
         return JoystickZone::Back;
     case sensors::JoystickZone::Origin:
         return JoystickZone::Origin;
-        // default:
-        // spdlog::error("Unexpected sensors joystick zone {}, defaulting to origin", zone);
+    default:
+        spdlog::error("Unexpected sensors joystick zone {}, defaulting to origin", zone);
     }
     return JoystickZone::Origin;
 }
@@ -140,10 +138,9 @@ sensors::InputSource convertInputSourceToProto(const InputSource inputSource)
         return sensors::InputSource::ChairVirtual;
     case InputSource::ChairPhysical:
         return sensors::InputSource::ChairPhysical;
-        // default:
-        //     spdlog::error("Unexpected luci input source {}, defaulting to chair virtual input
-        //     source",
-        //                   inputSource);
+    default:
+        spdlog::error("Unexpected luci input source {}, defaulting to chair virtual input source",
+                      static_cast<int>(inputSource));
     }
     return sensors::InputSource::ChairVirtual;
 }
@@ -162,10 +159,10 @@ InputSource convertProtoInputSource(const sensors::InputSource inputSource)
         return InputSource::ChairVirtual;
     case sensors::InputSource::ChairPhysical:
         return InputSource::ChairPhysical;
-        // default:
-        //     spdlog::error(
-        //         "Unexpected sensors input source {}, defaulting to chair virtual input source",
-        //         inputSource);
+    default:
+        spdlog::error(
+            "Unexpected sensors input source {}, defaulting to chair virtual input source",
+            inputSource);
     }
     return InputSource::ChairVirtual;
 }
@@ -179,61 +176,7 @@ ClientGuide::~ClientGuide()
     spdlog::debug("gRPC Ramp threads joined");
 }
 
-bool ClientGuide::activateEngagedMode() const
-{
-    ClientContext context;
-    Response response;
-    ModeCtrl request;
-    request.set_mode(DriveMode::ENGAGED);
-
-    if (Status status = stub_->SetDriveMode(&context, request, &response); status.ok())
-    {
-        spdlog::warn(response.reply());
-    }
-    else
-    {
-        return false;
-    }
-    return true;
-}
-
-bool ClientGuide::activateUserMode() const
-{
-    ClientContext context;
-    Response response;
-    ModeCtrl request;
-    request.set_mode(DriveMode::USER);
-
-    if (Status status = stub_->SetDriveMode(&context, request, &response); status.ok())
-    {
-        spdlog::warn(response.reply());
-    }
-    else
-    {
-        return false;
-    }
-    return true;
-}
-
-bool ClientGuide::activateAutoMode() const
-{
-    ClientContext context;
-    Response response;
-    ModeCtrl request;
-    request.set_mode(DriveMode::AUTONOMOUS);
-
-    if (Status status = stub_->SetDriveMode(&context, request, &response); status.ok())
-    {
-        spdlog::warn(response.reply());
-    }
-    else
-    {
-        return false;
-    }
-    return true;
-}
-
-void ClientGuide::setInputSource(InputSource source) const
+int ClientGuide::setInputSource(InputSource source) const
 {
     ClientContext context;
     sensors::InputSourceRequest request;
@@ -244,10 +187,12 @@ void ClientGuide::setInputSource(InputSource source) const
     if (Status status = stub_->AddInputSource(&context, request, &response); status.ok())
     {
         spdlog::info("Setting input source to {}", static_cast<int>(source));
+        return 0;
     }
     else
     {
         spdlog::error("Error communicating with server... pass in correct ip and port of chair");
+        return 1;
     }
 }
 

--- a/luci_grpc_interface/interface/CMakeLists.txt
+++ b/luci_grpc_interface/interface/CMakeLists.txt
@@ -1,4 +1,4 @@
-# # Copyright (c) 2023 LUCI Mobility, Inc. All Rights Reserved.
+# Copyright (c) 2023 LUCI Mobility, Inc. All Rights Reserved.
 
 # Find all the needed libraries for ROS
 find_package(ament_cmake REQUIRED)

--- a/luci_grpc_interface/interface/CMakeLists.txt
+++ b/luci_grpc_interface/interface/CMakeLists.txt
@@ -9,6 +9,7 @@ find_package(geometry_msgs REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(luci_messages REQUIRED)
+find_package(std_srvs REQUIRED)
 
 # Make a gRPC<-> ROS2 library
 add_library(ROS2GrpcInterfaceNode
@@ -23,6 +24,7 @@ target_include_directories(ROS2GrpcInterfaceNode PUBLIC
     ${nav_msgs_INCLUDE_DIRS}
     ${tf2_ros_INCLUDE_DIRS}
     ${luci_messages_INCLUDE_DIRS}
+    ${std_srvs_INCLUDE_DIRS}
 )
 
 # Link all the libraries 
@@ -36,6 +38,7 @@ target_link_libraries(ROS2GrpcInterfaceNode PUBLIC
     ${geometry_msgs_LIBRARIES}
     ${tf2_ros_LIBRARIES}
     ${luci_messages_LIBRARIES}
+    ${std_srvs_LIBRARIES}
 )
 
 # Make the interface node executable

--- a/luci_grpc_interface/interface/CMakeLists.txt
+++ b/luci_grpc_interface/interface/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 LUCI Mobility, Inc. All Rights Reserved.
+# # Copyright (c) 2023 LUCI Mobility, Inc. All Rights Reserved.
 
 # Find all the needed libraries for ROS
 find_package(ament_cmake REQUIRED)

--- a/luci_grpc_interface/interface/include/grpc_interface/interface.h
+++ b/luci_grpc_interface/interface/include/grpc_interface/interface.h
@@ -119,12 +119,6 @@ class Interface : public rclcpp::Node
             "luci/remote_joystick", QUEUE_SIZE,
             [this](luci_messages::msg::LuciJoystick::SharedPtr msg) { this->sendJsCallback(msg); });
 
-        this->luci_mode_switch_subscription_ =
-            this->create_subscription<luci_messages::msg::LuciDriveMode>(
-                "luci/drive_mode", QUEUE_SIZE,
-                [this](luci_messages::msg::LuciDriveMode::SharedPtr msg)
-                { this->switchLuciModeCallback(msg); });
-
         this->set_remote_input_service = this->create_service<std_srvs::srv::Empty>(
             "luci/set_remote_input",
             [this](const std::shared_ptr<rmw_request_id_t> request_header,
@@ -213,8 +207,6 @@ class Interface : public rclcpp::Node
 
     /// Shared pointers to subscribers (convention in ROS2)
     rclcpp::Subscription<luci_messages::msg::LuciJoystick>::SharedPtr remote_js_subscription_;
-    rclcpp::Subscription<luci_messages::msg::LuciDriveMode>::SharedPtr
-        luci_mode_switch_subscription_;
 
     rclcpp::Service<std_srvs::srv::Empty>::SharedPtr set_remote_input_service;
     rclcpp::Service<std_srvs::srv::Empty>::SharedPtr remove_remote_input_service;
@@ -260,7 +252,8 @@ class Interface : public rclcpp::Node
 
     /// Subscriber callback ran in main thread
     void sendJsCallback(const luci_messages::msg::LuciJoystick::SharedPtr msg);
-    void switchLuciModeCallback(const luci_messages::msg::LuciDriveMode::SharedPtr msg);
+
+    /// Service Callbacks ran in main thread for setting and removing the remote input source
     void setRemoteInputSource();
     void removeRemoteInputSource();
 };

--- a/luci_grpc_interface/interface/include/grpc_interface/interface.h
+++ b/luci_grpc_interface/interface/include/grpc_interface/interface.h
@@ -39,8 +39,8 @@
 #include <nav_msgs/msg/odometry.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
-#include <tf2_ros/transform_broadcaster.h>
 #include <std_srvs/srv/empty.hpp>
+#include <tf2_ros/transform_broadcaster.h>
 
 // LUCI ROS2 libraries
 #include <luci_messages/msg/luci_camera_info.hpp>
@@ -117,28 +117,30 @@ class Interface : public rclcpp::Node
         /// gRPC)
         this->remote_js_subscription_ = this->create_subscription<luci_messages::msg::LuciJoystick>(
             "luci/remote_joystick", QUEUE_SIZE,
-            [this](luci_messages::msg::LuciJoystick::SharedPtr msg) { this->sendJsCallback(msg); });   
-     
+            [this](luci_messages::msg::LuciJoystick::SharedPtr msg) { this->sendJsCallback(msg); });
+
         this->luci_mode_switch_subscription_ =
             this->create_subscription<luci_messages::msg::LuciDriveMode>(
                 "luci/drive_mode", QUEUE_SIZE,
                 [this](luci_messages::msg::LuciDriveMode::SharedPtr msg)
                 { this->switchLuciModeCallback(msg); });
-        
+
         this->set_remote_input_service = this->create_service<std_srvs::srv::Empty>(
             "luci/set_remote_input",
             [this](const std::shared_ptr<rmw_request_id_t> request_header,
                    const std::shared_ptr<std_srvs::srv::Empty::Request> request,
-                   const std::shared_ptr<std_srvs::srv::Empty::Response> response) {
+                   const std::shared_ptr<std_srvs::srv::Empty::Response> response)
+            {
                 RCLCPP_INFO(this->get_logger(), "Set remote input service called");
                 this->setRemoteInputSource();
             });
-        
+
         this->remove_remote_input_service = this->create_service<std_srvs::srv::Empty>(
             "luci/remove_remote_input",
             [this](const std::shared_ptr<rmw_request_id_t> request_header,
                    const std::shared_ptr<std_srvs::srv::Empty::Request> request,
-                   const std::shared_ptr<std_srvs::srv::Empty::Response> response) {
+                   const std::shared_ptr<std_srvs::srv::Empty::Response> response)
+            {
                 RCLCPP_INFO(this->get_logger(), "Remove remote input service called");
                 this->removeRemoteInputSource();
             });
@@ -171,7 +173,6 @@ class Interface : public rclcpp::Node
         this->rearCameraInfoPublisher = this->create_publisher<luci_messages::msg::LuciCameraInfo>(
             "luci/rear_camera_info", QUEUE_SIZE);
 
-
         // TODO: clp Should the processing just be handled in the gRPC threads?
         // Spin up a single thread for every gRPC <-> ROS translation
         grpcConverters.emplace_back(&Interface::processCameraData, this);
@@ -186,7 +187,6 @@ class Interface : public rclcpp::Node
         grpcConverters.emplace_back(&Interface::processLeftIrData, this);
         grpcConverters.emplace_back(&Interface::processRightIrData, this);
         grpcConverters.emplace_back(&Interface::processRearIrData, this);
-
     }
 
     /// Destructor
@@ -248,7 +248,7 @@ class Interface : public rclcpp::Node
     void processZoneScalingData();
     void processJoystickScalingData();
     void processJoystickPositionData();
-    void processAhrsData();    
+    void processAhrsData();
     void processImuData();
     void processEncoderData();
     void processLeftIrData();

--- a/luci_grpc_interface/interface/include/grpc_interface/interface.h
+++ b/luci_grpc_interface/interface/include/grpc_interface/interface.h
@@ -152,6 +152,7 @@ class Interface : public rclcpp::Node
         this->rearCameraInfoPublisher = this->create_publisher<luci_messages::msg::LuciCameraInfo>(
             "luci/rear_camera_info", QUEUE_SIZE);
 
+
         // TODO: clp Should the processing just be handled in the gRPC threads?
         // Spin up a single thread for every gRPC <-> ROS translation
         grpcConverters.emplace_back(&Interface::processCameraData, this);
@@ -166,6 +167,8 @@ class Interface : public rclcpp::Node
         grpcConverters.emplace_back(&Interface::processLeftIrData, this);
         grpcConverters.emplace_back(&Interface::processRightIrData, this);
         grpcConverters.emplace_back(&Interface::processRearIrData, this);
+
+        RCLCPP_INFO(this->get_logger(), "IN interface public, setup works??");
     }
 
     /// Destructor
@@ -224,7 +227,7 @@ class Interface : public rclcpp::Node
     void processZoneScalingData();
     void processJoystickScalingData();
     void processJoystickPositionData();
-    void processAhrsData();
+    void processAhrsData();    
     void processImuData();
     void processEncoderData();
     void processLeftIrData();

--- a/luci_grpc_interface/interface/include/grpc_interface/interface.h
+++ b/luci_grpc_interface/interface/include/grpc_interface/interface.h
@@ -79,20 +79,20 @@ class Interface : public rclcpp::Node
         std::shared_ptr<Luci::ROS2::DataBuffer<pcl::PointCloud<pcl::PointXYZ>>> ultrasonicDataBuff,
         std::shared_ptr<Luci::ROS2::DataBuffer<SystemJoystick>> joystickDataBuff,
         std::shared_ptr<Luci::ROS2::DataBuffer<LuciZoneScaling>> zoneScalingDataBuff,
-        std::shared_ptr<Luci::ROS2::DataBuffer<SystemJoystick>> joystickScalingDataBuff,
+        std::shared_ptr<Luci::ROS2::DataBuffer<LuciJoystickScaling>> joystickScalingDataBuff,
         std::shared_ptr<Luci::ROS2::DataBuffer<AhrsInfo>> ahrsInfoDataBuff,
         std::shared_ptr<Luci::ROS2::DataBuffer<ImuData>> imuDataBuff,
         std::shared_ptr<Luci::ROS2::DataBuffer<EncoderData>> encoderDataBuff,
         std::shared_ptr<Luci::ROS2::DataBuffer<CameraIrData>> irDataBuffLeft,
         std::shared_ptr<Luci::ROS2::DataBuffer<CameraIrData>> irDataBuffRight,
-        std::shared_ptr<Luci::ROS2::DataBuffer<CameraIrData>> irDataBuffRear)
+        std::shared_ptr<Luci::ROS2::DataBuffer<CameraIrData>> irDataBuffRear, int initialFrameRate)
         : Node("interface"), luciInterface(luciInterface), cameraDataBuff(cameraDataBuff),
           radarDataBuff(radarDataBuff), ultrasonicDataBuff(ultrasonicDataBuff),
           joystickDataBuff(joystickDataBuff), zoneScalingDataBuff(zoneScalingDataBuff),
           joystickScalingDataBuff(joystickScalingDataBuff), ahrsInfoDataBuff(ahrsInfoDataBuff),
           imuDataBuff(imuDataBuff), encoderDataBuff(encoderDataBuff),
           irDataBuffLeft(irDataBuffLeft), irDataBuffRight(irDataBuffRight),
-          irDataBuffRear(irDataBuffRear)
+          irDataBuffRear(irDataBuffRear), initialFrameRate(initialFrameRate)
     {
         /// ROS publishers (sends the LUCI gRPC data to ROS on the specified topic)
         this->cameraPublisher =
@@ -119,24 +119,44 @@ class Interface : public rclcpp::Node
             "luci/remote_joystick", QUEUE_SIZE,
             [this](luci_messages::msg::LuciJoystick::SharedPtr msg) { this->sendJsCallback(msg); });
 
-        this->set_remote_input_service = this->create_service<std_srvs::srv::Empty>(
-            "luci/set_remote_input",
+        this->set_shared_remote_input_service = this->create_service<std_srvs::srv::Empty>(
+            "luci/set_shared_remote_input",
             [this](const std::shared_ptr<rmw_request_id_t> request_header,
                    const std::shared_ptr<std_srvs::srv::Empty::Request> request,
                    const std::shared_ptr<std_srvs::srv::Empty::Response> response)
             {
                 RCLCPP_INFO(this->get_logger(), "Set remote input service called");
-                this->setRemoteInputSource();
+                this->setSharedRemoteInputSource();
             });
 
-        this->remove_remote_input_service = this->create_service<std_srvs::srv::Empty>(
-            "luci/remove_remote_input",
+        this->remove_shared_remote_input_service = this->create_service<std_srvs::srv::Empty>(
+            "luci/remove_shared_remote_input",
             [this](const std::shared_ptr<rmw_request_id_t> request_header,
                    const std::shared_ptr<std_srvs::srv::Empty::Request> request,
                    const std::shared_ptr<std_srvs::srv::Empty::Response> response)
             {
                 RCLCPP_INFO(this->get_logger(), "Remove remote input service called");
-                this->removeRemoteInputSource();
+                this->removeSharedRemoteInputSource();
+            });
+
+        this->set_auto_remote_input_service = this->create_service<std_srvs::srv::Empty>(
+            "luci/set_auto_remote_input",
+            [this](const std::shared_ptr<rmw_request_id_t> request_header,
+                   const std::shared_ptr<std_srvs::srv::Empty::Request> request,
+                   const std::shared_ptr<std_srvs::srv::Empty::Response> response)
+            {
+                RCLCPP_INFO(this->get_logger(), "Set auto remote input service called");
+                this->setAutoRemoteInputSource();
+            });
+
+        this->remove_auto_remote_input_service = this->create_service<std_srvs::srv::Empty>(
+            "luci/remove_auto_remote_input",
+            [this](const std::shared_ptr<rmw_request_id_t> request_header,
+                   const std::shared_ptr<std_srvs::srv::Empty::Request> request,
+                   const std::shared_ptr<std_srvs::srv::Empty::Response> response)
+            {
+                RCLCPP_INFO(this->get_logger(), "Remove auto remote input service called");
+                this->removeAutoRemoteInputSource();
             });
 
         this->zoneScalingPublisher =
@@ -149,23 +169,30 @@ class Interface : public rclcpp::Node
         this->joystickPositionPublisher = this->create_publisher<luci_messages::msg::LuciJoystick>(
             "luci/joystick_position", QUEUE_SIZE);
 
-        this->irLeftPublisher =
-            this->create_publisher<sensor_msgs::msg::Image>("luci/ir_left_camera", QUEUE_SIZE);
+        // get the camera frame rate from the gRPC interface
+        if (this->initialFrameRate != 0)
+        {
+            this->irLeftPublisher =
+                this->create_publisher<sensor_msgs::msg::Image>("luci/ir_left_camera", QUEUE_SIZE);
 
-        this->irRightPublisher =
-            this->create_publisher<sensor_msgs::msg::Image>("luci/ir_right_camera", QUEUE_SIZE);
+            this->irRightPublisher =
+                this->create_publisher<sensor_msgs::msg::Image>("luci/ir_right_camera", QUEUE_SIZE);
 
-        this->irRearPublisher =
-            this->create_publisher<sensor_msgs::msg::Image>("luci/ir_rear_camera", QUEUE_SIZE);
+            this->irRearPublisher =
+                this->create_publisher<sensor_msgs::msg::Image>("luci/ir_rear_camera", QUEUE_SIZE);
 
-        this->leftCameraInfoPublisher = this->create_publisher<luci_messages::msg::LuciCameraInfo>(
-            "luci/left_camera_info", QUEUE_SIZE);
+            this->leftCameraInfoPublisher =
+                this->create_publisher<luci_messages::msg::LuciCameraInfo>("luci/left_camera_info",
+                                                                           QUEUE_SIZE);
 
-        this->rightCameraInfoPublisher = this->create_publisher<luci_messages::msg::LuciCameraInfo>(
-            "luci/right_camera_info", QUEUE_SIZE);
+            this->rightCameraInfoPublisher =
+                this->create_publisher<luci_messages::msg::LuciCameraInfo>("luci/right_camera_info",
+                                                                           QUEUE_SIZE);
 
-        this->rearCameraInfoPublisher = this->create_publisher<luci_messages::msg::LuciCameraInfo>(
-            "luci/rear_camera_info", QUEUE_SIZE);
+            this->rearCameraInfoPublisher =
+                this->create_publisher<luci_messages::msg::LuciCameraInfo>("luci/rear_camera_info",
+                                                                           QUEUE_SIZE);
+        }
 
         // TODO: clp Should the processing just be handled in the gRPC threads?
         // Spin up a single thread for every gRPC <-> ROS translation
@@ -208,8 +235,11 @@ class Interface : public rclcpp::Node
     /// Shared pointers to subscribers (convention in ROS2)
     rclcpp::Subscription<luci_messages::msg::LuciJoystick>::SharedPtr remote_js_subscription_;
 
-    rclcpp::Service<std_srvs::srv::Empty>::SharedPtr set_remote_input_service;
-    rclcpp::Service<std_srvs::srv::Empty>::SharedPtr remove_remote_input_service;
+    /// Shared pointers to services (convention in ROS2)
+    rclcpp::Service<std_srvs::srv::Empty>::SharedPtr set_shared_remote_input_service;
+    rclcpp::Service<std_srvs::srv::Empty>::SharedPtr remove_shared_remote_input_service;
+    rclcpp::Service<std_srvs::srv::Empty>::SharedPtr set_auto_remote_input_service;
+    rclcpp::Service<std_srvs::srv::Empty>::SharedPtr remove_auto_remote_input_service;
 
     std::shared_ptr<tf2_ros::TransformBroadcaster> odomBroadcaster =
         std::make_shared<tf2_ros::TransformBroadcaster>(this);
@@ -224,7 +254,7 @@ class Interface : public rclcpp::Node
     std::shared_ptr<Luci::ROS2::DataBuffer<pcl::PointCloud<pcl::PointXYZ>>> radarDataBuff;
     std::shared_ptr<Luci::ROS2::DataBuffer<pcl::PointCloud<pcl::PointXYZ>>> ultrasonicDataBuff;
     std::shared_ptr<Luci::ROS2::DataBuffer<LuciZoneScaling>> zoneScalingDataBuff;
-    std::shared_ptr<Luci::ROS2::DataBuffer<SystemJoystick>> joystickScalingDataBuff;
+    std::shared_ptr<Luci::ROS2::DataBuffer<LuciJoystickScaling>> joystickScalingDataBuff;
     std::shared_ptr<Luci::ROS2::DataBuffer<SystemJoystick>> joystickDataBuff;
     std::shared_ptr<Luci::ROS2::DataBuffer<AhrsInfo>> ahrsInfoDataBuff;
     std::shared_ptr<Luci::ROS2::DataBuffer<ImuData>> imuDataBuff;
@@ -232,6 +262,7 @@ class Interface : public rclcpp::Node
     std::shared_ptr<Luci::ROS2::DataBuffer<CameraIrData>> irDataBuffLeft;
     std::shared_ptr<Luci::ROS2::DataBuffer<CameraIrData>> irDataBuffRight;
     std::shared_ptr<Luci::ROS2::DataBuffer<CameraIrData>> irDataBuffRear;
+    int initialFrameRate;
 
     /// Functions to handle each unique data type and convert (each are ran on independent threads)
     void processCameraData();
@@ -253,7 +284,9 @@ class Interface : public rclcpp::Node
     /// Subscriber callback ran in main thread
     void sendJsCallback(const luci_messages::msg::LuciJoystick::SharedPtr msg);
 
-    /// Service Callbacks ran in main thread for setting and removing the remote input source
-    void setRemoteInputSource();
-    void removeRemoteInputSource();
+    /// Service Callbacks ran in main thread for setting and removing the Shared and Autonomous remote input source
+    void setSharedRemoteInputSource();
+    void removeSharedRemoteInputSource();
+    void setAutoRemoteInputSource();
+    void removeAutoRemoteInputSource();
 };

--- a/luci_grpc_interface/interface/src/interface.cpp
+++ b/luci_grpc_interface/interface/src/interface.cpp
@@ -29,7 +29,7 @@ void Interface::processCameraData()
         // Camera point cloud processing
         auto cameraPointCloud = this->cameraDataBuff->waitNext();
 
-        spdlog::info("Number of camera points: {}", cameraPointCloud.size());
+        // spdlog::info("Number of camera points: {}", cameraPointCloud.size());
         sensor_msgs::msg::PointCloud2 rosCameraPointCloud;
 
         pcl::toROSMsg(cameraPointCloud, rosCameraPointCloud);
@@ -378,9 +378,10 @@ void Interface::processRearIrData()
 void Interface::sendJsCallback(const luci_messages::msg::LuciJoystick::SharedPtr msg)
 {
     // Send the remote JS values over gRPC
-    spdlog::debug("Received js val: {} {}", msg->forward_back, msg->left_right);
+    auto inputSource = static_cast<InputSource>(msg->input_source);
+    spdlog::debug("Received js val: {} {} {}", msg->forward_back, msg->left_right, msg->input_source);
 
-    this->luciInterface->sendJS(msg->forward_back + 100, msg->left_right + 100);
+    this->luciInterface->sendJS(msg->forward_back + 100, msg->left_right + 100, inputSource);
 }
 
 void Interface::switchLuciModeCallback(const luci_messages::msg::LuciDriveMode::SharedPtr msg)
@@ -402,6 +403,14 @@ void Interface::switchLuciModeCallback(const luci_messages::msg::LuciDriveMode::
         spdlog::error("NOT A VALID MODE SELECTION");
         break;
     }
+}
+
+void Interface::setRemoteInputSource() {
+    this->luciInterface->setInputSource(InputSource::Remote);
+}
+
+void Interface::removeRemoteInputSource() {
+    this->luciInterface->removeInputSource(InputSource::Remote);
 }
 
 void Interface::updateIrFrameRate(int rate)

--- a/luci_grpc_interface/interface/src/interface.cpp
+++ b/luci_grpc_interface/interface/src/interface.cpp
@@ -112,7 +112,8 @@ void Interface::processJoystickScalingData()
         luci_messages::msg::LuciJoystickScaling joystickScalingMsg;
         joystickScalingMsg.forward_back = joystickScalingData.forward_back;
         joystickScalingMsg.left_right = joystickScalingData.left_right;
-        joystickScalingMsg.joystick_zone = joystickScalingData.joystick_zone;
+        joystickScalingMsg.joystick_zone = static_cast<int>(joystickScalingData.joystick_zone);
+        joystickScalingMsg.input_source = static_cast<int>(joystickScalingData.input_source);
         this->joystickScalingPublisher->publish(joystickScalingMsg);
     }
 }
@@ -125,7 +126,8 @@ void Interface::processJoystickPositionData()
         luci_messages::msg::LuciJoystick joystickPositionMsg;
         joystickPositionMsg.forward_back = joystickPositionData.forward_back;
         joystickPositionMsg.left_right = joystickPositionData.left_right;
-        joystickPositionMsg.joystick_zone = joystickPositionData.joystick_zone;
+        joystickPositionMsg.joystick_zone = static_cast<int>(joystickPositionData.joystick_zone);
+        joystickPositionMsg.input_source = static_cast<int>(joystickPositionData.input_source);
         this->joystickPositionPublisher->publish(joystickPositionMsg);
     }
 }

--- a/luci_grpc_interface/interface/src/interface.cpp
+++ b/luci_grpc_interface/interface/src/interface.cpp
@@ -379,7 +379,8 @@ void Interface::sendJsCallback(const luci_messages::msg::LuciJoystick::SharedPtr
 {
     // Send the remote JS values over gRPC
     auto inputSource = static_cast<InputSource>(msg->input_source);
-    spdlog::debug("Received js val: {} {} {}", msg->forward_back, msg->left_right, msg->input_source);
+    spdlog::debug("Received js val: {} {} {}", msg->forward_back, msg->left_right,
+                  msg->input_source);
 
     this->luciInterface->sendJS(msg->forward_back + 100, msg->left_right + 100, inputSource);
 }
@@ -405,11 +406,10 @@ void Interface::switchLuciModeCallback(const luci_messages::msg::LuciDriveMode::
     }
 }
 
-void Interface::setRemoteInputSource() {
-    this->luciInterface->setInputSource(InputSource::Remote);
-}
+void Interface::setRemoteInputSource() { this->luciInterface->setInputSource(InputSource::Remote); }
 
-void Interface::removeRemoteInputSource() {
+void Interface::removeRemoteInputSource()
+{
     this->luciInterface->removeInputSource(InputSource::Remote);
 }
 

--- a/luci_grpc_interface/interface/src/interface.cpp
+++ b/luci_grpc_interface/interface/src/interface.cpp
@@ -114,6 +114,8 @@ void Interface::processJoystickScalingData()
         joystickScalingMsg.left_right = joystickScalingData.left_right;
         joystickScalingMsg.joystick_zone = static_cast<int>(joystickScalingData.joystick_zone);
         joystickScalingMsg.input_source = static_cast<int>(joystickScalingData.input_source);
+        joystickScalingMsg.forward_back_scaling = joystickScalingData.forward_back_scaling;
+        joystickScalingMsg.left_right_scaling = joystickScalingData.left_right_scaling;
         this->joystickScalingPublisher->publish(joystickScalingMsg);
     }
 }
@@ -385,40 +387,24 @@ void Interface::sendJsCallback(const luci_messages::msg::LuciJoystick::SharedPtr
     this->luciInterface->sendJS(msg->forward_back + 100, msg->left_right + 100, inputSource);
 }
 
-void Interface::setRemoteInputSource()
+void Interface::setSharedRemoteInputSource()
 {
-    int checker = this->luciInterface->setInputSource(InputSource::Remote);
-    std::chrono::milliseconds waitTime(100);
-    if (checker == 0)
-    {
-        this->luciInterface->sendJS(100, 100, InputSource::Remote);
-        while (true)
-        {
-            // Make sure that the joysick value is 0,0 before sending other values
-            // This is a behavior of LUCI and iss to prevent hangups when it thinks the joystick is
-            // not at 0,0
-            if (this->joystickDataBuff->waitNext(waitTime).has_value() == false ||
-                this->joystickDataBuff->getLatest().value().input_source != InputSource::Remote)
-            {
-                this->luciInterface->sendJS(100, 100, InputSource::Remote);
-            }
-            else
-            {
-                spdlog::info("Input source is remote");
-                break;
-            }
-            checker = 1;
-        }
-    }
-    else
-    {
-        spdlog::error("Error setting input source to remote");
-    }
+    this->luciInterface->setInputSource(InputSource::SharedRemote);
 }
 
-void Interface::removeRemoteInputSource()
+void Interface::removeSharedRemoteInputSource()
 {
-    this->luciInterface->removeInputSource(InputSource::Remote);
+    this->luciInterface->removeInputSource(InputSource::SharedRemote);
+}
+
+void Interface::setAutoRemoteInputSource()
+{
+    this->luciInterface->setInputSource(InputSource::AutonomousRemote);
+}
+
+void Interface::removeAutoRemoteInputSource()
+{
+    this->luciInterface->removeInputSource(InputSource::AutonomousRemote);
 }
 
 void Interface::updateIrFrameRate(int rate)

--- a/luci_grpc_interface/interface/src/main.cpp
+++ b/luci_grpc_interface/interface/src/main.cpp
@@ -21,6 +21,7 @@
 #include "client/client.h"
 #include "grpc_interface/interface.h"
 #include "tclap/CmdLine.h"
+#include "rclcpp/rclcpp.hpp"
 
 #include <iostream>
 
@@ -36,25 +37,29 @@ int main(int argc, char* argv[])
     std::string host;
     std::string port;
 
+    
     // Setup command line parser
     TCLAP::CmdLine cmd("LUCI ROS2 to gRPC interface", ' ', "---");
+    
 
     // Command to pass in chair ip address in gRPC mode
     TCLAP::ValueArg<std::string> hostArg("a", "host-address", "The host address. gRPC mode only.",
                                          true, "", "string");
+    
 
     // Command to pass in chair port in gRPC mode
     TCLAP::ValueArg<std::string> portArg("p", "gRPC-port", "Port number. gRPC mode only.", false,
                                          "50051", "string");
 
     // Command to pass in camera frame rate in gRPC mode
-    TCLAP::ValueArg<int> rateArg("f", "frame-rate", "IR Frame Rate gRPC mode only.", false, 0,
-                                 "int");
+    // TCLAP::ValueArg<int> rateArg("f", "frame-rate", "IR Frame Rate gRPC mode only.", false, 0,
+    //                              "int");
 
+    
     // Add the value arguments to the command line parser
     cmd.add(hostArg);
     cmd.add(portArg);
-    cmd.add(rateArg);
+    // cmd.add(rateArg);
 
     // Parse the argv array.
     cmd.parse(argc, argv);
@@ -62,7 +67,9 @@ int main(int argc, char* argv[])
     // Set the host and port values (if not set defaults used)
     host = hostArg.getValue();
     port = portArg.getValue();
-    int frameRate = rateArg.getValue();
+    // int frameRate = rateArg.getValue();
+
+    int frameRate = 0;
 
     // Initialize ROS stack and executor, Note: all argument parsing is handled externally by tclap
     rclcpp::init(0, nullptr);
@@ -113,14 +120,16 @@ int main(int argc, char* argv[])
         zoneScalingDataBuff, joystickScalingDataBuff, ahrsInfoDataBuff, imuDataBuff,
         encoderDataBuff, irDataBuffLeft, irDataBuffRight, irDataBuffRear, frameRate);
 
-    // ROS connection
+    // // ROS connection
     auto interface_node = std::make_shared<Interface>(
         luciInterface, cameraDataBuff, radarDataBuff, ultrasonicDataBuff, joystickDataBuff,
         zoneScalingDataBuff, joystickScalingDataBuff, ahrsInfoDataBuff, imuDataBuff,
         encoderDataBuff, irDataBuffLeft, irDataBuffRight, irDataBuffRear);
 
-    executor.add_node(interface_node);
+    // executor.add_node(interface_node);
     spdlog::debug("Running grpc interface");
+    
+    RCLCPP_INFO(rclcpp::get_logger("luci_interface"), "Running ROS2 executor...");
 
     executor.spin();
 

--- a/luci_grpc_interface/interface/src/main.cpp
+++ b/luci_grpc_interface/interface/src/main.cpp
@@ -49,13 +49,13 @@ int main(int argc, char* argv[])
                                          "50051", "string");
 
     // Command to pass in camera frame rate in gRPC mode
-    // TCLAP::ValueArg<int> rateArg("f", "frame-rate", "IR Frame Rate gRPC mode only.", false, 0,
-    //                              "int");
+    TCLAP::ValueArg<int> rateArg("f", "frame-rate", "IR Frame Rate gRPC mode only.", false, 0,
+                                 "int");
 
     // Add the value arguments to the command line parser
     cmd.add(hostArg);
     cmd.add(portArg);
-    // cmd.add(rateArg);
+    cmd.add(rateArg);
 
     // Parse the argv array.
     cmd.parse(argc, argv);
@@ -63,9 +63,7 @@ int main(int argc, char* argv[])
     // Set the host and port values (if not set defaults used)
     host = hostArg.getValue();
     port = portArg.getValue();
-    // int frameRate = rateArg.getValue();
-
-    int frameRate = 0;
+    int frameRate = rateArg.getValue();
 
     // Initialize ROS stack and executor, Note: all argument parsing is handled externally by tclap
     rclcpp::init(0, nullptr);

--- a/luci_grpc_interface/interface/src/main.cpp
+++ b/luci_grpc_interface/interface/src/main.cpp
@@ -20,8 +20,8 @@
 
 #include "client/client.h"
 #include "grpc_interface/interface.h"
-#include "tclap/CmdLine.h"
 #include "rclcpp/rclcpp.hpp"
+#include "tclap/CmdLine.h"
 
 #include <iostream>
 
@@ -37,15 +37,12 @@ int main(int argc, char* argv[])
     std::string host;
     std::string port;
 
-    
     // Setup command line parser
     TCLAP::CmdLine cmd("LUCI ROS2 to gRPC interface", ' ', "---");
-    
 
     // Command to pass in chair ip address in gRPC mode
     TCLAP::ValueArg<std::string> hostArg("a", "host-address", "The host address. gRPC mode only.",
                                          true, "", "string");
-    
 
     // Command to pass in chair port in gRPC mode
     TCLAP::ValueArg<std::string> portArg("p", "gRPC-port", "Port number. gRPC mode only.", false,
@@ -55,7 +52,6 @@ int main(int argc, char* argv[])
     // TCLAP::ValueArg<int> rateArg("f", "frame-rate", "IR Frame Rate gRPC mode only.", false, 0,
     //                              "int");
 
-    
     // Add the value arguments to the command line parser
     cmd.add(hostArg);
     cmd.add(portArg);
@@ -128,7 +124,7 @@ int main(int argc, char* argv[])
 
     executor.add_node(interface_node);
     spdlog::debug("Running grpc interface");
-    
+
     RCLCPP_INFO(rclcpp::get_logger("luci_interface"), "Running ROS2 executor...");
 
     executor.spin();

--- a/luci_grpc_interface/interface/src/main.cpp
+++ b/luci_grpc_interface/interface/src/main.cpp
@@ -126,7 +126,7 @@ int main(int argc, char* argv[])
         zoneScalingDataBuff, joystickScalingDataBuff, ahrsInfoDataBuff, imuDataBuff,
         encoderDataBuff, irDataBuffLeft, irDataBuffRight, irDataBuffRear);
 
-    // executor.add_node(interface_node);
+    executor.add_node(interface_node);
     spdlog::debug("Running grpc interface");
     
     RCLCPP_INFO(rclcpp::get_logger("luci_interface"), "Running ROS2 executor...");

--- a/luci_grpc_interface/interface/src/main.cpp
+++ b/luci_grpc_interface/interface/src/main.cpp
@@ -77,7 +77,7 @@ int main(int argc, char* argv[])
 
     auto zoneScalingDataBuff = std::make_shared<Luci::ROS2::DataBuffer<LuciZoneScaling>>();
 
-    auto joystickScalingDataBuff = std::make_shared<Luci::ROS2::DataBuffer<SystemJoystick>>();
+    auto joystickScalingDataBuff = std::make_shared<Luci::ROS2::DataBuffer<LuciJoystickScaling>>();
 
     auto ahrsInfoDataBuff = std::make_shared<Luci::ROS2::DataBuffer<AhrsInfo>>();
 
@@ -114,11 +114,11 @@ int main(int argc, char* argv[])
         zoneScalingDataBuff, joystickScalingDataBuff, ahrsInfoDataBuff, imuDataBuff,
         encoderDataBuff, irDataBuffLeft, irDataBuffRight, irDataBuffRear, frameRate);
 
-    // // ROS connection
+    // ROS connection
     auto interface_node = std::make_shared<Interface>(
         luciInterface, cameraDataBuff, radarDataBuff, ultrasonicDataBuff, joystickDataBuff,
         zoneScalingDataBuff, joystickScalingDataBuff, ahrsInfoDataBuff, imuDataBuff,
-        encoderDataBuff, irDataBuffLeft, irDataBuffRight, irDataBuffRear);
+        encoderDataBuff, irDataBuffLeft, irDataBuffRight, irDataBuffRear, frameRate);
 
     executor.add_node(interface_node);
     spdlog::debug("Running grpc interface");

--- a/luci_grpc_interface/package.xml
+++ b/luci_grpc_interface/package.xml
@@ -15,7 +15,6 @@
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>tf2_ros</depend>
-  <!-- Note not including the luci_message package here as its easier to build without it needing to be in rosdep -->
   <depend>luci_messages</depend>
 
   <export>

--- a/luci_grpc_interface/package.xml
+++ b/luci_grpc_interface/package.xml
@@ -16,7 +16,7 @@
   <depend>nav_msgs</depend>
   <depend>tf2_ros</depend>
   <!-- Note not including the luci_message package here as its easier to build without it needing to be in rosdep -->
-  <!-- <depend>luci_messages</depend> -->
+  <depend>luci_messages</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/luci_grpc_interface/sensors_grpc/gen-proto.sh
+++ b/luci_grpc_interface/sensors_grpc/gen-proto.sh
@@ -54,9 +54,6 @@ else
     echo $CPP_PLUGIN
 fi
 
-echo "PROTOC=${PROTOC}"
-echo "CPP_PLUGIN=${CPP_PLUGIN}"
-
 PLUGIN=protoc-gen-grpc=${CPP_PLUGIN}
 OUTPUT_DIR=${CMAKE_CURRENT_BINARY_DIR}/generated_code/sensors_grpc
 HASH_FILE=${OUTPUT_DIR}/proto-hash.md5

--- a/luci_grpc_interface/sensors_grpc/gen-proto.sh
+++ b/luci_grpc_interface/sensors_grpc/gen-proto.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-set -e
+echo "A"
+set -e 
+echo "B"
 
 USAGE="Usage: gen-proto.sh CMAKE_CURRENT_SOURCE_DIR CMAKE_BINARY_DIR CMAKE_CURRENT_BINARY_DIR"
 
@@ -26,6 +28,7 @@ if [[ -z ${3} ]]; then
     echo >&2 ${USAGE}
     exit 1
 fi
+echo "C"
 
 CMAKE_CURRENT_SOURCE_DIR=${1}
 CMAKE_BINARY_DIR=${2}
@@ -38,9 +41,12 @@ PROTOFILE_PATH=${CMAKE_CURRENT_SOURCE_DIR}/sensors.proto
 PROTOC=protoc
 CPP_PLUGIN=grpc_cpp_plugin
 
+echo "D"
+
 CONAN_PROTOC=${CMAKE_BINARY_DIR}/bin/${PROTOC}
 CONAN_CPP_PLUGIN=${CMAKE_BINARY_DIR}/bin/${CPP_PLUGIN}
 
+echo "E"
 if [[ -x ${CONAN_PROTOC} ]]; then
     PROTOC=${CONAN_PROTOC}
 fi
@@ -51,7 +57,10 @@ else
     # Protoc does not search the PATH when looking for plugins,
     # so we must provide the full path.
     CPP_PLUGIN=$(which ${CPP_PLUGIN})
+    echo $CPP_PLUGIN
 fi
+
+echo "F"
 
 echo "PROTOC=${PROTOC}"
 echo "CPP_PLUGIN=${CPP_PLUGIN}"

--- a/luci_grpc_interface/sensors_grpc/gen-proto.sh
+++ b/luci_grpc_interface/sensors_grpc/gen-proto.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
-echo "A"
-set -e 
-echo "B"
+set -e
 
 USAGE="Usage: gen-proto.sh CMAKE_CURRENT_SOURCE_DIR CMAKE_BINARY_DIR CMAKE_CURRENT_BINARY_DIR"
 
@@ -28,7 +26,6 @@ if [[ -z ${3} ]]; then
     echo >&2 ${USAGE}
     exit 1
 fi
-echo "C"
 
 CMAKE_CURRENT_SOURCE_DIR=${1}
 CMAKE_BINARY_DIR=${2}
@@ -41,12 +38,9 @@ PROTOFILE_PATH=${CMAKE_CURRENT_SOURCE_DIR}/sensors.proto
 PROTOC=protoc
 CPP_PLUGIN=grpc_cpp_plugin
 
-echo "D"
-
 CONAN_PROTOC=${CMAKE_BINARY_DIR}/bin/${PROTOC}
 CONAN_CPP_PLUGIN=${CMAKE_BINARY_DIR}/bin/${CPP_PLUGIN}
 
-echo "E"
 if [[ -x ${CONAN_PROTOC} ]]; then
     PROTOC=${CONAN_PROTOC}
 fi
@@ -59,8 +53,6 @@ else
     CPP_PLUGIN=$(which ${CPP_PLUGIN})
     echo $CPP_PLUGIN
 fi
-
-echo "F"
 
 echo "PROTOC=${PROTOC}"
 echo "CPP_PLUGIN=${CPP_PLUGIN}"

--- a/luci_grpc_interface/sensors_grpc/sensors.proto
+++ b/luci_grpc_interface/sensors_grpc/sensors.proto
@@ -37,6 +37,7 @@ service Sensors {
   rpc AhrsStream(google.protobuf.Empty) returns (stream AhrsData); //
 
   rpc ScalingStream(google.protobuf.Empty) returns (stream NavigationScaling); //
+  rpc ActiveScalingStream(google.protobuf.Empty) returns (stream ActiveScaling); //
 
   rpc DecimatedCameraStream(google.protobuf.Empty)
       returns (stream CameraPoints); //
@@ -86,6 +87,12 @@ message NavigationScaling {
   float back_rl = 16;
   uint32 max_js_scale_increase = 17;
   uint32 max_js_scale_decrease = 18;
+}
+
+message ActiveScaling {
+  JoystickData joystick = 1;
+  float forward_back_scaling = 2;
+  float left_right_scaling = 3;
 }
 
 message UltrasonicDistance {
@@ -317,10 +324,11 @@ message FrameRate {
 
 enum InputSource {
 RampAssist = 0;
-Remote = 1;
+AutonomousRemote = 1;
 WDI = 2;
 ChairVirtual = 3;
 ChairPhysical = 4;
+SharedRemote = 5;
 }
 
 message InputSourceRequest {

--- a/luci_grpc_interface/sensors_grpc/sensors.proto
+++ b/luci_grpc_interface/sensors_grpc/sensors.proto
@@ -29,11 +29,10 @@ service Sensors {
       returns (stream UltrasonicDistances); //
 
   rpc RadarStream(google.protobuf.Empty) returns (stream RadarPoints); //
-  rpc ImuStream(ImuCtrl) returns (stream ImuData); //
-  rpc JoystickStream(google.protobuf.Empty) returns (stream JoystickData); //
+  rpc ImuStream(ImuCtrl) returns (stream ImuData); // 
+  rpc DriveJoystickStream(google.protobuf.Empty) returns (stream JoystickData); //
 
-
-  rpc ScaledJoystickStream(google.protobuf.Empty) returns (stream JoystickData); //
+  rpc UserJoystickStream(google.protobuf.Empty) returns (stream JoystickData); //
   rpc AhrsStream(google.protobuf.Empty) returns (stream AhrsData); //
 
   rpc ScalingStream(google.protobuf.Empty) returns (stream NavigationScaling); //
@@ -183,11 +182,24 @@ message ImuData {
   Imu source = 28;
 }
 
+enum JoystickZone {
+  Front = 0;
+  FrontLeft = 1;
+  FrontRight = 2;
+  Left = 3;
+  Right = 4;
+  BackLeft = 5;
+  BackRight = 6;
+  Back = 7;
+  Origin = 8;
+}
+
 message JoystickData {
   int32 forward_back = 1;
   int32 left_right = 2;
-  string joystick_zone = 3;
-  google.protobuf.Timestamp timestamp = 4;
+  JoystickZone joystick_zone = 3;
+  InputSource source = 4;
+  google.protobuf.Timestamp timestamp = 5;
 }
 
 message EncoderData {
@@ -313,4 +325,16 @@ message RampMode {
 
 message FrameRate {
   uint32 rate = 1;
+}
+
+enum InputSource {
+RampAssist = 0;
+Remote = 1;
+WDI = 2;
+ChairVirtual = 3;
+ChairPhysical = 4;
+}
+
+message InputSourceRequest {
+InputSource source = 1;
 }

--- a/luci_grpc_interface/sensors_grpc/sensors.proto
+++ b/luci_grpc_interface/sensors_grpc/sensors.proto
@@ -24,6 +24,8 @@ package sensors;
 service Sensors {
 
   rpc JsOverride(RemoteJsValues) returns (Response); //
+  rpc AddInputSource(InputSourceRequest) returns (Response);
+  rpc RemoveInputSource(InputSourceRequest) returns (Response);
   rpc SetDriveMode(ModeCtrl) returns (Response); //
   rpc UltrasonicStream(google.protobuf.Empty)
       returns (stream UltrasonicDistances); //
@@ -295,6 +297,7 @@ message IrFrame {
 message RemoteJsValues {
   int32 forward_back = 1;
   int32 left_right = 2;
+  InputSource source = 3;
 }
 
 // USER mode => luci nominal operations

--- a/luci_grpc_interface/sensors_grpc/sensors.proto
+++ b/luci_grpc_interface/sensors_grpc/sensors.proto
@@ -26,7 +26,6 @@ service Sensors {
   rpc JsOverride(RemoteJsValues) returns (Response); //
   rpc AddInputSource(InputSourceRequest) returns (Response);
   rpc RemoveInputSource(InputSourceRequest) returns (Response);
-  rpc SetDriveMode(ModeCtrl) returns (Response); //
   rpc UltrasonicStream(google.protobuf.Empty)
       returns (stream UltrasonicDistances); //
 
@@ -298,20 +297,6 @@ message RemoteJsValues {
   int32 forward_back = 1;
   int32 left_right = 2;
   InputSource source = 3;
-}
-
-// USER mode => luci nominal operations
-// ENGAGED => Override JS values only when joystick engaged
-// AUTONOMOUS => Override Js values without joystick engaged
-enum DriveMode {
-  USER = 0;
-  ENGAGED = 1;
-  AUTONOMOUS = 2;
-  PLAYBACK = 3;
-}
-
-message ModeCtrl {
-  DriveMode mode = 1;
 }
 
 message ChairSpeed {


### PR DESCRIPTION
Upgrades support for LUCI-3.X

- Support for LUCI joystick changes in the new version - Includes fixes for remote joystick
  - Input source can now be set using services rather than changing Drivemode parameter
  - Removed Drive mode parameter as not used anymore
- Support LUCI camera stream changes
- Changes in Proto file structure to match LUCI-3.x changes
- Added clang formatting file from luci-sensors to have streamlined formatting

Testing - 
Performed on SPV-1. Camera stream information on bitbucket

This update will tie in with https://github.com/lucimobility/luci-ros2-msgs/pull/20