### PR TITLE
depth ir images time sync

### DIFF
--- a/luci_grpc_interface/client/include/client/common_types.h
+++ b/luci_grpc_interface/client/include/client/common_types.h
@@ -267,11 +267,15 @@ struct CameraIrData
     CameraTransform transform;
     std::vector<uint8_t> data;
     int rotationType;
+    int32_t timestamp_sec;
+    uint32_t timestamp_nsec;
 
     inline CameraIrData(int width, int height, CameraIntrinsics intrinsics,
-                        CameraTransform transform, int rotationType, std::vector<uint8_t> data)
+                        CameraTransform transform, int rotationType, std::vector<uint8_t> data,
+                        int32_t timestamp_sec, uint32_t timestamp_nsec)
         : width(width), height(height), intrinsics(intrinsics), transform(transform),
-          rotationType(rotationType), data(data)
+          rotationType(rotationType), data(data), timestamp_sec(timestamp_sec),
+          timestamp_nsec(timestamp_nsec)
     {
     }
 };
@@ -285,9 +289,13 @@ struct CameraDepthData
     int width;
     int height;
     std::vector<uint8_t> data;
+    int32_t timestamp_sec;
+    uint32_t timestamp_nsec;
 
-    inline CameraDepthData(int width, int height, std::vector<uint8_t> data)
-        : width(width), height(height), data(data)
+    inline CameraDepthData(int width, int height, std::vector<uint8_t> data,
+                           int32_t timestamp_sec, uint32_t timestamp_nsec)
+        : width(width), height(height), data(data), timestamp_sec(timestamp_sec),
+          timestamp_nsec(timestamp_nsec)
     {
     }
 };

--- a/luci_grpc_interface/client/src/client.cpp
+++ b/luci_grpc_interface/client/src/client.cpp
@@ -753,7 +753,9 @@ void ClientGuide::readIrFrame(int initialRate)
         }
 
         CameraIrData cameraIrData =
-            CameraIrData(response.width(), response.height(), intrinsics, transform, type, bytes);
+            CameraIrData(response.width(), response.height(), intrinsics, transform, type, bytes,
+                         response.timestamp().seconds(),
+                         static_cast<uint32_t>(response.timestamp().nanos()));
         {
             if (response.camera() == "left")
             {
@@ -796,7 +798,9 @@ void ClientGuide::readDepthFrame()
     {
         CameraDepthData cameraDepthData(
             response.width(), response.height(),
-            std::vector<uint8_t>(response.frame().begin(), response.frame().end()));
+            std::vector<uint8_t>(response.frame().begin(), response.frame().end()),
+            response.timestamp().seconds(),
+            static_cast<uint32_t>(response.timestamp().nanos()));
         if (response.camera() == "left")
         {
             this->depthDataBuffLeft->push(cameraDepthData);

--- a/luci_grpc_interface/interface/src/interface.cpp
+++ b/luci_grpc_interface/interface/src/interface.cpp
@@ -302,7 +302,7 @@ void Interface::processLeftIrData()
         // Header
         std_msgs::msg::Header irHeader;
         irHeader.frame_id = "left_camera";
-        irHeader.stamp = this->get_clock()->now();
+        irHeader.stamp = rclcpp::Time(leftIrData.timestamp_sec, leftIrData.timestamp_nsec);
 
         rosIrMsg.header = irHeader;
         cameraInfoMsg.header = irHeader;
@@ -344,7 +344,7 @@ void Interface::processRightIrData()
         // Header
         std_msgs::msg::Header irHeader;
         irHeader.frame_id = "right_camera";
-        irHeader.stamp = this->get_clock()->now();
+        irHeader.stamp = rclcpp::Time(rightIrData.timestamp_sec, rightIrData.timestamp_nsec);
 
         rosIrMsg.header = irHeader;
         cameraInfoMsg.header = irHeader;
@@ -386,7 +386,7 @@ void Interface::processRearIrData()
         // Header
         std_msgs::msg::Header irHeader;
         irHeader.frame_id = "rear_camera";
-        irHeader.stamp = this->get_clock()->now();
+        irHeader.stamp = rclcpp::Time(rearIrData.timestamp_sec, rearIrData.timestamp_nsec);
 
         rosIrMsg.header = irHeader;
         cameraInfoMsg.header = irHeader;
@@ -425,7 +425,7 @@ void Interface::processLeftDepthData()
         sensor_msgs::msg::Image depthMsg;
 
         depthMsg.header.frame_id = "left_depth_camera";
-        depthMsg.header.stamp = this->get_clock()->now();
+        depthMsg.header.stamp = rclcpp::Time(leftDepthData.timestamp_sec, leftDepthData.timestamp_nsec);
 
         depthMsg.height = leftDepthData.height;
         depthMsg.width = leftDepthData.width;
@@ -452,7 +452,7 @@ void Interface::processRightDepthData()
         sensor_msgs::msg::Image depthMsg;
 
         depthMsg.header.frame_id = "right_depth_camera";
-        depthMsg.header.stamp = this->get_clock()->now();
+        depthMsg.header.stamp = rclcpp::Time(rightDepthData.timestamp_sec, rightDepthData.timestamp_nsec);
 
         depthMsg.height = rightDepthData.height;
         depthMsg.width = rightDepthData.width;
@@ -479,7 +479,7 @@ void Interface::processRearDepthData()
         sensor_msgs::msg::Image depthMsg;
 
         depthMsg.header.frame_id = "rear_depth_camera";
-        depthMsg.header.stamp = this->get_clock()->now();
+        depthMsg.header.stamp = rclcpp::Time(rearDepthData.timestamp_sec, rearDepthData.timestamp_nsec);
 
         depthMsg.height = rearDepthData.height;
         depthMsg.width = rearDepthData.width;


### PR DESCRIPTION
## 📌 Description

Syncing depth and IR image timestamp by using the timestamps through grpc

### Development Changes

N/A

## 🧪 Testing

Tested on the Q500M at LUCI. Also tested at Northwestern.

## 🔗 Related Issue(s)

LUCI-1543 on JIRA

## ⚠️ Risks

N/A. Should help with mapping and other situations. 

## 📚 Documentation

N/A
